### PR TITLE
Add hashbang comment to cli.ts so it becomes executable

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import fs from 'fs';
 import util from 'util';
 import { parse } from 'src/parser';


### PR DESCRIPTION
The first release of this tool was missing the hashbang which is necessary to make it run with `tsc-output-parser` command. Without the hashbang, bash parses it as bash code which doesn't work.