### PR TITLE
Re-export parser from module root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+// Re-export parser functionality from the root of the module
+export * from 'src/parser';


### PR DESCRIPTION
This allows using the module as the readme guides

```typescript
import { parse } from '@aivenio/tsc-output-parser';
```

instead of:
```typescript
import { parse } from '@aivenio/tsc-output-parser/parser';
```
