### PR TITLE
Add typings manually to the package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
-// Re-export parser functionality from the root of the module
+// Re-export parser functionality and typing from the root of the module
 export * from 'src/parser';
+export * from 'src/parserTypes';

--- a/src/parserTypes.ts
+++ b/src/parserTypes.ts
@@ -1,0 +1,42 @@
+// ts-pegjs plugin supports returnTypes in the config json file
+// but it didn't affect the generated output at all. See these issues:
+// https://github.com/metadevpro/ts-pegjs/issues/46
+// https://github.com/metadevpro/ts-pegjs/issues/27
+// https://github.com/pegjs/pegjs/issues/562
+
+// As a workaround, we expose the types here
+export interface GrammarPath {
+  type: 'Path',
+  value: string,
+}
+
+export interface GrammarCursor {
+  type: 'Cursor',
+  value: {
+    line: number,
+    col: number,
+  },
+}
+
+export interface GrammarTsError {
+  type: 'TsError',
+  value: {
+    type: 'error' | 'warning',
+    errorString: string,
+  },
+}
+
+export interface GrammarMessage {
+  type: 'Message',
+  value: string,
+}
+
+export interface GrammarItem {
+  type: 'Item',
+  value: {
+    path: GrammarPath,
+    cursor: GrammarCursor,
+    tsError: GrammarTsError,
+    message: GrammarMessage,
+  },
+}

--- a/src/tsc-grammar.pegjs
+++ b/src/tsc-grammar.pegjs
@@ -21,6 +21,7 @@ Main = _ items:(Item)* _ { return items }
 
 Item = path:Path cursor:Cursor ":" _ tsError:TsError _ ":" message:Message {
   return {
+    // NOTE! If you change the types, remember to also change the parserTypes.ts
     type: 'Item',
     value: {
       path,


### PR DESCRIPTION
tspeg-js didn't export the types even though the "returnTypes" option was set in the json and passed as a cli argument.

This is a workaround to export the grammar typing.