### PR TITLE
doc: add link to repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
   },
   "author": "Aiven",
   "license": "Apache 2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aiven/tsc-output-parser"
+  },
   "devDependencies": {
     "@aivenio/eslint-config-aiven": "^1.0.0",
     "@typescript-eslint/eslint-plugin": "^4.1.0",


### PR DESCRIPTION
Hello!

This PR add link to repository to find source from npm registry.

Current published version does not contains link to source repository.

![Capture d’écran 2022-02-11 à 08 33 30](https://user-images.githubusercontent.com/2315749/153552967-aac6f5ef-dd76-4642-a6b5-2fe5e6972c5a.png)

